### PR TITLE
Fix R file names

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2118,10 +2118,8 @@ const fileIcons: FileIcons = {
       'r',
       'rsweave',
     ],
-    fileExtensions: [
-      'r',
-    ],
-    fileNames: ['.rhistory'],
+    fileExtensions: ['R', 'r'],
+    fileNames: ['.Rhistory'],
   },
   'racket': {
     fileExtensions: ['rkt'],
@@ -2137,7 +2135,7 @@ const fileIcons: FileIcons = {
     ],
   },
   'rdata': {
-    fileExtensions: ['rdata'],
+    fileExtensions: ['RData'],
   },
   'readme': {
     fileNames: [
@@ -2183,7 +2181,7 @@ const fileIcons: FileIcons = {
     fileExtensions: ['res'],
   },
   'rmd': {
-    fileExtensions: ['rmd'],
+    fileExtensions: ['Rmd'],
   },
   'roblox': {
     fileExtensions: ['rbxl', 'rbxlx', 'rbxm', 'rbxmx'],
@@ -2223,7 +2221,7 @@ const fileIcons: FileIcons = {
     ],
   },
   'rproj': {
-    fileExtensions: ['rproj'],
+    fileExtensions: ['Rproj'],
   },
   'rsml': {
     fileExtensions: ['rsml'],


### PR DESCRIPTION
@prazdevs, i fixed some filenames that you did recently; feel free to fix things if i missed something + it would be nicer to use the actual .Rhistory file icon that i had in [this issue](https://github.com/catppuccin/vscode-icons/issues/401).

Using Zed to test the visibility of these icons so idk whether it will change things on the vscode side or not.

(Closed due to not reading the contribution rules first)