### PR TITLE
feat(associations): `gd.uid` to `godot-assets`

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1063,6 +1063,7 @@ const fileIcons: FileIcons = {
       'gdshader',
       'gdshaderinc',
       'gdextension',
+      'gd.uid',
     ],
     fileNames: [
       '.gdignore',


### PR DESCRIPTION
This commit adds Godot's UID files (introduced in Godot 4.4) to the `godot-assets` file icons.

For more details see https://godotengine.org/article/uid-changes-coming-to-godot-4-4/