### PR TITLE
Add support for '.avsc' file extension and filename

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1405,6 +1405,7 @@ const fileIcons: FileIcons = {
       'ndjson',
       'hjson',
       'webmanifest',
+      'avsc'
     ],
     fileNames: [
       '.jscsrc',
@@ -1415,6 +1416,7 @@ const fileIcons: FileIcons = {
       'cdp.pid',
       '.lintstagedrc',
       '.whitesource',
+      '.avsc'
     ],
   },
   'juce': {


### PR DESCRIPTION
I just added support for .avsc files to follow the JSON patterns, I hope you’ll accept it!
<img width="467" height="262" alt="image" src="https://github.com/user-attachments/assets/c73a040d-8353-4bed-a47e-800dd1864966" />
