### PR TITLE
fix(scripts): ignore non-SVG files

### DIFF
--- a/scripts/icons/generate.ts
+++ b/scripts/icons/generate.ts
@@ -16,7 +16,7 @@ try {
   let generated = 0
   for (const origin of folders) {
     const originPath = resolve('icons', origin)
-    const originSvgs = await readdir(originPath)
+    const originSvgs = (await readdir(originPath)).filter(f => f.endsWith('.svg'))
 
     for (const dest of folders.filter(f => f !== origin)) {
       const destPath = resolve('icons', dest)

--- a/scripts/icons/optimize.ts
+++ b/scripts/icons/optimize.ts
@@ -14,60 +14,68 @@ try {
   Promise.all(folders.map(async (flavor) => {
     const flavorPath = resolve('icons', flavor)
     const svgs = await readdir(flavorPath)
-    await Promise.all(svgs.map(async (s) => {
-      const svgPath = resolve(flavorPath, s)
-      const str = await readFile(svgPath, 'utf8')
-      const svg = new SVG(str)
-      cleanupSVG(svg)
-      runSVGO(svg, { plugins: [
-        'cleanupAttrs',
-        'cleanupEnableBackground',
-        'cleanupIds',
-        'cleanupListOfValues',
-        'cleanupNumericValues',
-        'collapseGroups',
-        'convertColors',
-        'convertEllipseToCircle',
-        'convertShapeToPath',
-        'convertStyleToAttrs',
-        'convertTransform',
-        'inlineStyles',
-        'mergePaths',
-        'mergeStyles',
-        'minifyStyles',
-        'moveElemsAttrsToGroup',
-        'removeComments',
-        'removeDesc',
-        'removeDoctype',
-        'removeEditorsNSData',
-        'removeEmptyAttrs',
-        'removeEmptyContainers',
-        'removeEmptyText',
-        'removeHiddenElems',
-        'removeMetadata',
-        'removeNonInheritableGroupAttrs',
-        'removeRasterImages',
-        'removeScriptElement',
-        'removeStyleElement',
-        'removeTitle',
-        'removeUnknownsAndDefaults',
-        'removeUnusedNS',
-        'removeUselessDefs',
-        'removeUselessStrokeAndFill',
-        'removeXMLProcInst',
-        'sortAttrs',
-        'sortDefsChildren',
-      ], multipass: true })
-      await writeFile(
-        svgPath,
-        svg.toPrettyString()
-          .replaceAll(/#[A-F0-9]{6}/gi, s => s.toLowerCase()),
-      )
-    }))
-  }))
+    await Promise.all(svgs
+      .filter(s => s.endsWith('.svg'))
+      .map(async (s) => {
+        const svgPath = resolve(flavorPath, s)
+        const str = await readFile(svgPath, 'utf8')
+        const svg = new SVG(str)
+
+        cleanupSVG(svg)
+        runSVGO(svg, {
+          plugins: [
+            'cleanupAttrs',
+            'cleanupEnableBackground',
+            'cleanupIds',
+            'cleanupListOfValues',
+            'cleanupNumericValues',
+            'collapseGroups',
+            'convertColors',
+            'convertEllipseToCircle',
+            'convertShapeToPath',
+            'convertStyleToAttrs',
+            'convertTransform',
+            'inlineStyles',
+            'mergePaths',
+            'mergeStyles',
+            'minifyStyles',
+            'moveElemsAttrsToGroup',
+            'removeComments',
+            'removeDesc',
+            'removeDoctype',
+            'removeEditorsNSData',
+            'removeEmptyAttrs',
+            'removeEmptyContainers',
+            'removeEmptyText',
+            'removeHiddenElems',
+            'removeMetadata',
+            'removeNonInheritableGroupAttrs',
+            'removeRasterImages',
+            'removeScriptElement',
+            'removeStyleElement',
+            'removeTitle',
+            'removeUnknownsAndDefaults',
+            'removeUnusedNS',
+            'removeUselessDefs',
+            'removeUselessStrokeAndFill',
+            'removeXMLProcInst',
+            'sortAttrs',
+            'sortDefsChildren',
+          ],
+          multipass: true,
+        })
+        await writeFile(
+          svgPath,
+          svg.toPrettyString()
+            .replaceAll(/#[A-F0-9]{6}/gi, s => s.toLowerCase()),
+        )
+      }))
+  },
+  ))
   consola.success('Optimized SVG files.')
 }
-catch (error) {
+catch
+(error) {
   consola.error('Optimization failed: ', error)
   exit(1)
 }

--- a/scripts/icons/preview.ts
+++ b/scripts/icons/preview.ts
@@ -14,7 +14,7 @@ import { launch } from 'puppeteer'
 try {
   consola.info('Generating previews...')
 
-  const allIcons = await readdir('icons/latte')
+  const allIcons = (await readdir('icons/latte')).filter(s => s.endsWith('.svg'))
   const fileIcons = allIcons.filter(i => !i.startsWith('folder_') && !i.startsWith('_'))
   const folderIcons = allIcons.filter(i => i.startsWith('folder_') && !i.endsWith('_open.svg'))
 


### PR DESCRIPTION
This fixes an issue I had while working on #619. I use a Mac, which love to create `.DS_Store` files everywhere whenever you open a folder in finder.