### PR TITLE
Add `requirements-all.txt` to Python config icon

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2126,6 +2126,7 @@ const fileIcons: FileIcons = {
     fileNames: [
       'pyproject.toml',
       'requirements.txt',
+      'requirements-all.txt',
       'requirements-dev.txt',
       'requirements-test.txt',
       '.python-version',


### PR DESCRIPTION
There are over 400 files on GitHub (excluding forks) named `requirements-all.txt`: https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29requirements-all.txt%24%2F+NOT+is%3Afork&type=code

When you want to install *all* dependencies (base dependencies, dev dependencies, test dependencies, etc.), a `requirements-all.txt` can make that process a bit easier for the developer.