### PR TITLE
Add additional well-known Bazel file names to fileIcons

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -245,7 +245,7 @@ const fileIcons: FileIcons = {
   },
   'bazel': {
     fileExtensions: ['bzl', 'bazel'],
-    fileNames: ['.bazelrc'],
+    fileNames: ['BUILD', 'WORKSPACE', '.bazelrc'],
   },
   'benchmark': {
     fileNames: [


### PR DESCRIPTION
The `BUILD` and  `WORKSPACE` files can omit the `.bazel` suffix, but they are well known Bazel file names.

Reference: https://bazel.build/concepts/build-files