### PR TITLE
feat(associations): `.npmrc-publish` to `npm`

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1811,7 +1811,7 @@ const fileIcons: FileIcons = {
     fileNames: ['package-lock.json'],
   },
   'npm': {
-    fileNames: ['.npmrc'],
+    fileNames: ['.npmrc', '.npmrc-publish'],
   },
   'nuget': {
     fileNames: [


### PR DESCRIPTION
This PR is aiming to associate `.npmrc-publish` to the `npm` icon.

- `rushjs` is a javaScript monorepo tool developed by microsoft.
- `.npmrc-publish` used by the `rush publish` command, as publishing often involves different credentials.
  - Please see [.npmrc-publish](https://rushjs.io/pages/configs/npmrc-publish/)