### PR TITLE
give package.json5 and package.yaml files the same icon as package.json

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1866,6 +1866,8 @@ const fileIcons: FileIcons = {
   'package-json': {
     fileNames: [
       'package.json',
+      'package.json5',
+      'package.yaml',
       '.nvmrc',
       '.esmrc',
       '.node-version',


### PR DESCRIPTION
pnpm supports these files as alternatives to package.json: https://pnpm.io/package_json

we could perhaps also use the pnpm icon, but there's technically not anything preventing other package managers from supporting this in the future so I'm leaning towards keeping it neutral