### PR TITLE
feat(associations): `.gcloudignore` to `gcp`

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -981,8 +981,9 @@ const fileIcons: FileIcons = {
   },
   'gcp': {
     fileNames: [
-      'release-please-config.json',
+      '.gcloudignore',
       '.release-please-manifest.json',
+      'release-please-config.json',
     ],
   },
   'git-cliff': {


### PR DESCRIPTION
## Summary

- Associate `.gcloudignore` files with the existing `gcp` icon

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)