### PR TITLE
Add `.mailmap` as a Git file

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1014,6 +1014,7 @@ const fileIcons: FileIcons = {
       '.git-blame-ignore',
       '.git-blame-ignore-revs',
       '.git-for-windows-updater',
+      '.mailmap',
       'git-history',
     ],
   },


### PR DESCRIPTION
`.mailmap` files are used to map old or inaccurate committer names and
emails to the proper name and email.
